### PR TITLE
Update verion of Kabanero to 0.2.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,7 +50,7 @@ Kabanero's Spring Boot Collection contains all the components you need to develo
 
 == Getting started
 
-To obtain the Spring Boot Collection, Appsody must be configured to point to the Kabanero repository. The instructions in this guide use the public index for Kabanero Version 0.1.2, which you can replace with your enterprise-specific index if you have one.
+To obtain the Spring Boot Collection, Appsody must be configured to point to the Kabanero repository. The instructions in this guide use the public index for Kabanero Version 0.2.1, which you can replace with your enterprise-specific index if you have one.
 
 // =================================================================================================
 // Configuring Appsody
@@ -69,13 +69,13 @@ You see an output similar to the following example:
 ----
 appsody repo list
 NAME        URL
-*appsodyhub https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
+*incubator https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
 ----
 
 Next, run the following command to add the Kabanero index:
 [role="command"]
 ----
-appsody repo add kabanero https://github.com/kabanero-io/collections/releases/download/v0.1.2/kabanero-index.yaml
+appsody repo add kabanero https://github.com/kabanero-io/collections/releases/download/0.2.1/kabanero-index.yaml
 ----
 
 Check the available repositories again to see that the Kabanero repository was added:
@@ -83,11 +83,11 @@ Check the available repositories again to see that the Kabanero repository was a
 ----
 appsody repo list
 NAME        URL
-*appsodyhub https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-kabanero    https://github.com/kabanero-io/collections/releases/download/v0.1.2/kabanero-index.yaml
+*incubator https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
+kabanero    https://github.com/kabanero-io/collections/releases/download/0.2.1/kabanero-index.yaml
 ----
 
-In this example, the asterisk (*) shows that `appsodyhub` is the default repository. Run the following command to set the Kabanero index as the default repository:
+In this example, the asterisk (*) shows that `incubator` is the default repository. Run the following command to set the Kabanero index as the default repository:
 [role="command"]
 ----
 appsody repo set-default kabanero
@@ -98,8 +98,8 @@ Check the available repositories again to see that the default is updated:
 ----
 appsody repo list
 NAME        URL
-appsodyhub  https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-*kabanero   https://github.com/kabanero-io/collections/releases/download/v0.1.2/kabanero-index.yaml
+incubator   https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
+*kabanero   https://github.com/kabanero-io/collections/releases/download/0.2.1/kabanero-index.yaml
 ----
 
 Your Appsody CLI is now configured to use the Kabanero Collections. Next, you need to initialize your project.
@@ -127,7 +127,7 @@ The output from the command varies depending on whether you have an installation
 [source, role='no_copy']
 ----
 Running appsody init...
-Downloading java-spring-boot2 template project from https://github.com/kabanero-io/collections/releases/download/v0.1.2/incubator.java-spring-boot2.v0.3.9.templates.default.tar.gz
+Downloading java-spring-boot2 template project from https://github.com/kabanero-io/collections/releases/download/0.2.1/incubator.java-spring-boot2.v0.3.9.templates.default.tar.gz
 Download complete. Extracting files from java-spring-boot2.tar.gz
 Setting up the development environment
 Running command: docker[pull kabanero/java-spring-boot2:0.3]


### PR DESCRIPTION
Update all instances of Kabanero 0.1.2 to 0.2.1 per issue #4.
Update all references to repository `appsodyhub` to `incubator`
in line with changes at the Appsody project.

Closes: #4

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>